### PR TITLE
Use environment variables exported by the mysql cartridge.

### DIFF
--- a/config/databases/database.openshift.config.php-dist
+++ b/config/databases/database.openshift.config.php-dist
@@ -24,10 +24,10 @@
  */
 $_url = parse_url( getenv( 'CLEARDB_DATABASE_URL' ) );
 $_server = getenv('OPENSHIFT_MYSQL_DB_HOST');
-$_username = getenv('OPENSHIFT_MYSQL_DB_USER');
-$_password = getenv('OPENSHIFT_MYSQL_DB_PASS');
+$_username = getenv('OPENSHIFT_MYSQL_DB_USERNAME');
+$_password = getenv('OPENSHIFT_MYSQL_DB_PASSWORD');
 $_port = getenv('OPENSHIFT_MYSQL_DB_PORT');
-$_db = getenv('OPENSHIFT_MYSQL_DB_NAME');
+$_db = getenv('OPENSHIFT_APP_NAME');
 
 return array(
     'connectionString'      => 'mysql:host=' . $_server . ';port=' . $_port . ';dbname=' . $_db,


### PR DESCRIPTION
The mysql-5.5 cartridge on OpenShift [exports environment variables][2] for various database connection parameters. Currently, we require the user to manually export some variables expected by us in step 7 of the [wiki][1]. This is not required, provided we just use the names exported by the mysql cartridge.

Please also remove step 7 from the [wiki][1] when this is merged.



[1]: https://github.com/dreamfactorysoftware/dsp-core/wiki/Deploying-to-OpenShift
[2]: https://developers.openshift.com/en/databases-mysql.html